### PR TITLE
Rearrange CODEOWNERS to trigger compliance bot.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @dixahq/android @dixahq/ios @dixahq/frontend-io @dixahq/backend-io
+*       @dixahq/frontend-io @dixahq/backend-io @dixahq/android @dixahq/ios


### PR DESCRIPTION
SOC2 compliance bot for vulnerabilities only looks up at the first owner to determine where to send alerts. Choosing frontend-io as the first option.