### PR TITLE
Update rexml gem from 3.3.9 to 3.4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ ruby ">= 2.6.10"
 # bound in the template on Cocoapods with next React Native release.
 gem 'cocoapods', '1.15.0'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
-gem 'rexml', '3.3.9'
+gem 'rexml', '3.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     netrc (0.11.0)
     nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.3.9)
+    rexml (3.4.2)
     ruby-macho (2.5.1)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
@@ -97,7 +97,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (>= 6.1.7.5, < 7.1.0)
   cocoapods (= 1.15.0)
-  rexml (= 3.3.9)
+  rexml (= 3.4.2)
 
 RUBY VERSION
    ruby 2.6.10p210


### PR DESCRIPTION
## Summary
Updates the `rexml` gem dependency from version 3.3.9 to 3.4.2.

## Changes
- Updated `rexml` gem version in `Gemfile`
- Updated `Gemfile.lock` with new version