### PR TITLE
chore: reorder CODEOWNERS to put @dixahq/ios first

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @dixahq/frontend-io @dixahq/backend-io @dixahq/android @dixahq/ios
+*       @dixahq/ios @dixahq/android @dixahq/frontend-io @dixahq/backend-io


### PR DESCRIPTION
## Why

The utilities at `compliance-automation/` use the first codeowner listed as the primary reference for ownership. For React Native projects the iOS team is treated as the primary owner, so `@dixahq/ios` should appear first.

## What changed

Reordered the CODEOWNERS entry to `@dixahq/ios @dixahq/android @dixahq/frontend-io @dixahq/backend-io`. Same owners as before, just reordered.