### PR TITLE
Fix: bump activesupport to 7.0.10 to resolve ReDoS, DoS, and XSS CVEs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ ruby ">= 2.6.10"
 # Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
 # bound in the template on Cocoapods with next React Native release.
 gem 'cocoapods', '1.15.0'
-gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
+gem 'activesupport', '>= 6.1.7.10', '< 7.1.0'
 gem 'rexml', '3.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,12 +5,18 @@ GEM
       base64
       nkf
       rexml
-    activesupport (6.1.7.7)
+    activesupport (7.0.10)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     algoliasearch (1.27.5)
@@ -18,6 +24,8 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     base64 (0.2.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
     claide (1.1.0)
     cocoapods (1.15.0)
       addressable (~> 2.8)
@@ -57,7 +65,8 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.1)
+    concurrent-ruby (1.3.6)
+    drb (2.2.3)
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
@@ -66,18 +75,24 @@ GEM
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.14.5)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.7.2)
-    minitest (5.23.1)
+    logger (1.7.0)
+    minitest (6.0.5)
+      drb (~> 2.0)
+      prism (~> 1.5)
     molinillo (0.8.0)
+    mutex_m (0.3.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
     nkf (0.2.0)
+    prism (1.9.0)
     public_suffix (4.0.7)
     rexml (3.4.2)
     ruby-macho (2.5.1)
+    securerandom (0.4.1)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
@@ -89,18 +104,17 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (>= 3.3.2, < 4.0)
-    zeitwerk (2.6.15)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (>= 6.1.7.5, < 7.1.0)
+  activesupport (>= 6.1.7.10, < 7.1.0)
   cocoapods (= 1.15.0)
   rexml (= 3.4.2)
 
 RUBY VERSION
-   ruby 2.6.10p210
+  ruby 2.6.10p210
 
 BUNDLED WITH
-   1.17.2
+  4.0.10


### PR DESCRIPTION
PR summary:

- Resolves Dependabot alerts #54, #55, #56 (ActiveSupport ReDoS, DoS, and XSS vulnerabilities).
- The project was running activesupport 6.1.7.7, which is affected by all three CVEs. Bumped the Gemfile lower bound to >= 6.1.7.10; Bundler resolved 7.0.10 (the latest within the existing < 7.1.0 cap), which
- contains all fixes. CocoaPods 1.15.0 is unaffected by this upgrade.

- Raises the minimum activesupport bound from 6.1.7.5 to 6.1.7.10 in the
- Gemfile. Bundler resolved 7.0.10 (latest within the < 7.1.0 cap),
- fixing the number_to_delimited ReDoS, scientific-notation DoS, and
- SafeBuffer#% XSS vulnerabilities reported in Dependabot alerts #54-56.